### PR TITLE
Add Stage 1 Gadi COSIMA recipe smoke test workflow

### DIFF
--- a/.github/configs/cosima-all-recipes.yml
+++ b/.github/configs/cosima-all-recipes.yml
@@ -1,27 +1,21 @@
-# Multi-Recipe Configuration for COSIMA Recipes
-# This file defines multiple COSIMA recipes to run with their specific configurations
-
-# Global defaults that apply to all recipes unless overridden
+# Legacy YAML configuration retained for compatibility with older tooling.
+# The Stage 1 workflow uses .github/configs/cosima-smoke.json.
 defaults:
   type: cosima
   project: tm70
-  repository_url: https://github.com/COSIMA/cosima-recipes
+  repository_url: https://github.com/COSIMA/cosima-recipes.git
   conda_module: conda/analysis3
+  module_base_path: /g/data/xp65/public/modules
   config:
     queue: normal
-    walltime: "02:00:00" 
-    memory: 8GB
+    walltime: "00:30:00"
+    memory: 4GB
     group: small
-    storage: "gdata/kj13+gdata/fs38+gdata/oi10+gdata/rr3+gdata/v45+gdata/hh5"
+    storage: "gdata/xp65+gdata/ik11+gdata/cj50+gdata/ol01+gdata/hh5"
 
-# List of recipes to run
 recipes:
-  - name: Barotropic_Streamfunction.ipynb
-    enabled: true
-    config:
-      walltime: "00:30:00"
-      memory: 4GB
-  - name: Barotropic_Streamfunction.ipynb
+  - name: barotropic-streamfunction
+    path: 02-Appetisers/Barotropic_Streamfunction.ipynb
     enabled: true
     config:
       walltime: "00:30:00"

--- a/.github/configs/cosima-smoke.json
+++ b/.github/configs/cosima-smoke.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "defaults": {
+    "type": "cosima",
+    "repository_url": "https://github.com/COSIMA/cosima-recipes.git",
+    "recipes_ref": "main",
+    "project": "tm70",
+    "queue": "normal",
+    "walltime": "00:30:00",
+    "memory": "4GB",
+    "ncpus": 1,
+    "storage": "gdata/xp65+gdata/ik11+gdata/cj50+gdata/ol01+gdata/hh5",
+    "conda_module": "conda/analysis3",
+    "module_base_path": "/g/data/xp65/public/modules",
+    "poll_interval_seconds": 60,
+    "poll_timeout_minutes": 45
+  },
+  "notebooks": [
+    {
+      "name": "barotropic-streamfunction",
+      "path": "02-Appetisers/Barotropic_Streamfunction.ipynb",
+      "description": "Stage 1 smoke test notebook for COSIMA Recipes",
+      "walltime": "00:30:00",
+      "memory": "4GB"
+    }
+  ]
+}

--- a/.github/workflows/cosima-recipe.yml
+++ b/.github/workflows/cosima-recipe.yml
@@ -1,40 +1,176 @@
-name: COSIMA Recipe Test
+name: COSIMA Recipe Smoke Test
+
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
     inputs:
-      recipe_name:
-        description: 'Recipe name to run'
+      notebook_path:
+        description: 'Manifest notebook path to run'
         required: true
+        default: '02-Appetisers/Barotropic_Streamfunction.ipynb'
+      recipes_ref:
+        description: 'COSIMA/cosima-recipes branch, tag, or SHA to test'
+        required: true
+        default: 'main'
+      conda_module:
+        description: 'Analysis environment module to load on Gadi'
+        required: true
+        default: 'conda/analysis3'
+      module_base_path:
+        description: 'Module base path to add before loading conda_module'
+        required: true
+        default: '/g/data/xp65/public/modules'
+      poll_timeout_minutes:
+        description: 'How long GitHub Actions should poll for the PBS result'
+        required: true
+        default: '45'
+      gadi_work_dir:
+        description: 'Optional Gadi base work directory; defaults to GADI_SCRIPTS_DIR secret'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
-  setup:
+  smoke-test:
+    name: Run one COSIMA notebook on Gadi
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.recipes.outputs.matrix }}
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
-      - name: Generate Recipe Matrix  
-        id: recipes
-        uses: rbeucher/smart-recipe-runner@main
-        with:
-          config_file: '.github/configs/cosima-all-recipes.yml'
 
-  execute:
-    needs: setup
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Execute Recipe
-        uses: rbeucher/smart-recipe-runner@main
-        with:
-          gadi_username: ${{ secrets.GADI_USER }}
-          gadi_ssh_key: ${{ secrets.GADI_KEY }}
-          gadi_ssh_passphrase: ${{ secrets.GADI_KEY_PASSPHRASE }}
-          submit_job: 'true'
-          scripts_dir: ${{ secrets.GADI_SCRIPTS_DIR }}
+      - name: Plan smoke test
+        id: plan
+        env:
+          NOTEBOOK_PATH: ${{ inputs.notebook_path }}
+          RECIPES_REF: ${{ inputs.recipes_ref }}
+          CONDA_MODULE: ${{ inputs.conda_module }}
+          MODULE_BASE_PATH: ${{ inputs.module_base_path }}
+          POLL_TIMEOUT_MINUTES: ${{ inputs.poll_timeout_minutes }}
+        run: |
+          python3 scripts/plan_cosima_smoke.py \
+            --manifest .github/configs/cosima-smoke.json \
+            --notebook-path "$NOTEBOOK_PATH" \
+            --recipes-ref "$RECIPES_REF" \
+            --conda-module "$CONDA_MODULE" \
+            --module-base-path "$MODULE_BASE_PATH" \
+            --poll-timeout-minutes "$POLL_TIMEOUT_MINUTES" \
+            --out planned-run.json
+
+      - name: Configure SSH for Gadi
+        env:
+          GADI_KEY: ${{ secrets.GADI_KEY }}
+          GADI_KEY_PASSPHRASE: ${{ secrets.GADI_KEY_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          test -n "${{ secrets.GADI_USER }}" || { echo "GADI_USER secret is not configured" >&2; exit 2; }
+          test -n "$GADI_KEY" || { echo "GADI_KEY secret is not configured" >&2; exit 2; }
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$GADI_KEY" > ~/.ssh/gadi_key
+          chmod 600 ~/.ssh/gadi_key
+          ssh-keyscan -H gadi.nci.org.au >> ~/.ssh/known_hosts
+          eval "$(ssh-agent -s)"
+          if [[ -n "${GADI_KEY_PASSPHRASE:-}" ]]; then
+            ASKPASS=$(mktemp)
+            chmod 700 "$ASKPASS"
+            printf '#!/usr/bin/env bash\nprintf %%s "$GADI_KEY_PASSPHRASE"\n' > "$ASKPASS"
+            DISPLAY=:0 SSH_ASKPASS="$ASKPASS" SSH_ASKPASS_REQUIRE=force ssh-add ~/.ssh/gadi_key </dev/null
+            rm -f "$ASKPASS"
+          else
+            ssh-add ~/.ssh/gadi_key
+          fi
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
+
+      - name: Submit PBS job
+        id: submit
+        env:
+          GADI_USER: ${{ secrets.GADI_USER }}
+          GADI_WORK_DIR_INPUT: ${{ inputs.gadi_work_dir }}
+          GADI_WORK_DIR_SECRET: ${{ secrets.GADI_SCRIPTS_DIR }}
+        run: |
+          set -euo pipefail
+          GADI_WORK_DIR="${GADI_WORK_DIR_INPUT:-$GADI_WORK_DIR_SECRET}"
+          test -n "$GADI_WORK_DIR" || { echo "Provide gadi_work_dir or configure GADI_SCRIPTS_DIR secret" >&2; exit 2; }
+          RUN_DIR="${GADI_WORK_DIR%/}/cosima-recipes-ci/runs/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ steps.plan.outputs.safe_name }}"
+          ssh_opts=(-o BatchMode=yes -o StrictHostKeyChecking=yes)
+          ssh "${ssh_opts[@]}" "${GADI_USER}@gadi.nci.org.au" bash -s -- \
+            "$RUN_DIR" \
+            '${{ steps.plan.outputs.repository_url }}' \
+            '${{ steps.plan.outputs.recipes_ref }}' \
+            '${{ steps.plan.outputs.path }}' \
+            '${{ steps.plan.outputs.conda_module }}' \
+            '${{ steps.plan.outputs.module_base_path }}' \
+            '${{ steps.plan.outputs.project }}' \
+            '${{ steps.plan.outputs.queue }}' \
+            '${{ steps.plan.outputs.walltime }}' \
+            '${{ steps.plan.outputs.memory }}' \
+            '${{ steps.plan.outputs.ncpus }}' \
+            '${{ steps.plan.outputs.storage }}' \
+            < scripts/gadi_submit_cosima_smoke.sh | tee submit.json
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+import json
+with open('submit.json', encoding='utf-8') as handle:
+    data = json.load(handle)
+for key in ('pbs_job_id', 'run_dir', 'result_json', 'pbs_script'):
+    print(f'{key}={data[key]}')
+PY
+
+      - name: Poll PBS result
+        id: poll
+        env:
+          GADI_USER: ${{ secrets.GADI_USER }}
+        run: |
+          set +e
+          ssh_opts=(-o BatchMode=yes -o StrictHostKeyChecking=yes)
+          ssh "${ssh_opts[@]}" "${GADI_USER}@gadi.nci.org.au" bash -s -- \
+            '${{ steps.submit.outputs.result_json }}' \
+            '${{ steps.plan.outputs.poll_timeout_minutes }}' \
+            '${{ steps.plan.outputs.poll_interval_seconds }}' \
+            '${{ steps.submit.outputs.pbs_job_id }}' \
+            < scripts/gadi_poll_cosima_smoke.sh | tee result.json
+          poll_rc=${PIPESTATUS[0]}
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+import json
+try:
+    with open('result.json', encoding='utf-8') as handle:
+        data = json.load(handle)
+except Exception as exc:
+    data = {'status': 'invalid-result-json', 'error': str(exc)}
+for key, value in data.items():
+    if isinstance(value, (str, int, float)):
+        print(f'{key}={value}')
+PY
+          echo "poll_exit_code=$poll_rc" >> "$GITHUB_OUTPUT"
+
+      - name: Write job summary
+        run: |
+          set -euo pipefail
+          status='${{ steps.poll.outputs.status }}'
+          {
+            echo "## COSIMA Recipes smoke test"
+            echo
+            echo "- Notebook: \`${{ steps.plan.outputs.path }}\`"
+            echo "- COSIMA Recipes ref: \`${{ steps.plan.outputs.recipes_ref }}\`"
+            echo "- PBS job ID: \`${{ steps.submit.outputs.pbs_job_id }}\`"
+            echo "- Status: **${status:-unknown}**"
+            echo "- Gadi run directory: \`${{ steps.submit.outputs.run_dir }}\`"
+            echo "- Result JSON: \`${{ steps.submit.outputs.result_json }}\`"
+            echo "- analysis3 module: \`${{ steps.plan.outputs.conda_module }}\`"
+            echo "- module base path: \`${{ steps.plan.outputs.module_base_path }}\`"
+            if [[ -n '${{ steps.poll.outputs.log_path }}' ]]; then
+              echo "- Notebook log: \`${{ steps.poll.outputs.log_path }}\`"
+            fi
+            if [[ -n '${{ steps.poll.outputs.executed_notebook }}' ]]; then
+              echo "- Executed notebook: \`${{ steps.poll.outputs.executed_notebook }}\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$status" != "passed" ]]; then
+            echo "Smoke test did not pass: ${status:-unknown}" >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
-
-
 # ACCESS-NRI MED COSIMA-recipes Workflow
 
-ACCESS-NRI maintenance of COSIMA-recipes for the Australian Community.
+ACCESS-NRI maintenance workflow for testing COSIMA Recipes on NCI Gadi.
 
+## Stage 1 smoke test
+
+The active workflow, `.github/workflows/cosima-recipe.yml`, is manually dispatched and runs one manifest-listed notebook on Gadi via PBS:
+
+- `02-Appetisers/Barotropic_Streamfunction.ipynb`
+
+The workflow:
+
+1. Reads `.github/configs/cosima-smoke.json` and validates the requested notebook path.
+2. SSHes to Gadi using repository secrets.
+3. Creates a predictable run directory under `${GADI_SCRIPTS_DIR}/cosima-recipes-ci/runs/<github-run>-<attempt>-<notebook>/` unless `gadi_work_dir` is supplied at dispatch time.
+4. Clones/fetches `COSIMA/cosima-recipes`, checks out the requested ref, and validates that the notebook exists.
+5. Writes and submits a non-blocking PBS script using the configured `conda_module` and `module_base_path`.
+6. Polls for a result JSON file and writes the pass/fail outcome to the GitHub Actions summary.
+
+Required GitHub secrets:
+
+- `GADI_USER`
+- `GADI_KEY`
+- `GADI_KEY_PASSPHRASE` if the key is encrypted
+- `GADI_SCRIPTS_DIR` unless `gadi_work_dir` is supplied manually
+
+The Stage 1 workflow intentionally tests only one notebook. Expansion to a broader smoke suite should happen after this path proves reliable on Gadi.

--- a/scripts/gadi_poll_cosima_smoke.sh
+++ b/scripts/gadi_poll_cosima_smoke.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Poll for the result JSON from one COSIMA Recipes PBS job on Gadi.
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 RESULT_JSON TIMEOUT_MINUTES INTERVAL_SECONDS JOB_ID" >&2
+  exit 2
+fi
+
+RESULT_JSON=$1
+TIMEOUT_MINUTES=$2
+INTERVAL_SECONDS=$3
+JOB_ID=$4
+DEADLINE=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
+
+while [[ $(date +%s) -le $DEADLINE ]]; do
+  if [[ -s "$RESULT_JSON" ]]; then
+    cat "$RESULT_JSON"
+    exit 0
+  fi
+  if command -v qstat >/dev/null 2>&1 && ! qstat "$JOB_ID" >/dev/null 2>&1; then
+    # The job has left the queue but the result was not written. Wait one more
+    # interval for filesystem visibility, then report an actionable failure.
+    sleep "$INTERVAL_SECONDS"
+    if [[ -s "$RESULT_JSON" ]]; then
+      cat "$RESULT_JSON"
+      exit 0
+    fi
+    printf '{"status":"missing-result","pbs_job_id":"%s","result_json":"%s"}\n' "$JOB_ID" "$RESULT_JSON"
+    exit 4
+  fi
+  sleep "$INTERVAL_SECONDS"
+done
+
+printf '{"status":"timeout","pbs_job_id":"%s","result_json":"%s","timeout_minutes":%s}\n' "$JOB_ID" "$RESULT_JSON" "$TIMEOUT_MINUTES"
+exit 124

--- a/scripts/gadi_submit_cosima_smoke.sh
+++ b/scripts/gadi_submit_cosima_smoke.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Submit one COSIMA Recipes notebook to PBS on Gadi, non-blocking.
+set -euo pipefail
+
+if [[ $# -ne 12 ]]; then
+  echo "usage: $0 RUN_DIR REPO_URL RECIPES_REF NOTEBOOK_PATH CONDA_MODULE MODULE_BASE_PATH PROJECT QUEUE WALLTIME MEMORY NCPUS STORAGE" >&2
+  exit 2
+fi
+
+RUN_DIR=$1
+REPO_URL=$2
+RECIPES_REF=$3
+NOTEBOOK_PATH=$4
+CONDA_MODULE=$5
+MODULE_BASE_PATH=$6
+PROJECT=$7
+QUEUE=$8
+WALLTIME=$9
+MEMORY=${10}
+NCPUS=${11}
+STORAGE=${12}
+SAFE_NAME=$(printf '%s' "$NOTEBOOK_PATH" | sed -E 's#[^A-Za-z0-9_.-]+#-#g; s#^-+##; s#-+$##')
+[[ -n "$SAFE_NAME" ]] || SAFE_NAME=notebook
+PBS_JOB_NAME=$(printf '%s' "$SAFE_NAME" | sed -E 's#[^A-Za-z0-9_-]+#_#g' | cut -c1-40)
+[[ -n "$PBS_JOB_NAME" ]] || PBS_JOB_NAME=notebook
+
+case "$NOTEBOOK_PATH" in
+  /*|*..*) echo "unsafe notebook path: $NOTEBOOK_PATH" >&2; exit 2 ;;
+esac
+
+mkdir -p "$RUN_DIR" "$RUN_DIR/logs" "$RUN_DIR/results" "$RUN_DIR/outputs"
+SOURCE_DIR="$RUN_DIR/source"
+PBS_SCRIPT="$RUN_DIR/${SAFE_NAME}.pbs"
+SUBMISSION_JSON="$RUN_DIR/results/${SAFE_NAME}.submitted.json"
+RESULT_JSON="$RUN_DIR/results/${SAFE_NAME}.result.json"
+
+if [[ ! -d "$SOURCE_DIR/.git" ]]; then
+  git clone --filter=blob:none "$REPO_URL" "$SOURCE_DIR" >&2
+fi
+git -C "$SOURCE_DIR" fetch --depth=1 origin "$RECIPES_REF" >&2
+git -C "$SOURCE_DIR" checkout --detach FETCH_HEAD >&2
+COMMIT=$(git -C "$SOURCE_DIR" rev-parse HEAD)
+
+if [[ ! -f "$SOURCE_DIR/$NOTEBOOK_PATH" ]]; then
+  echo "notebook not found after checkout: $NOTEBOOK_PATH" >&2
+  exit 3
+fi
+
+cat > "$PBS_SCRIPT" <<EOF
+#!/usr/bin/env bash
+#PBS -P $PROJECT
+#PBS -q $QUEUE
+#PBS -l walltime=$WALLTIME
+#PBS -l mem=$MEMORY
+#PBS -l ncpus=$NCPUS
+#PBS -l storage=$STORAGE
+#PBS -l wd
+#PBS -N cosima_$PBS_JOB_NAME
+#PBS -o $RUN_DIR/logs/${SAFE_NAME}.pbs.out
+#PBS -e $RUN_DIR/logs/${SAFE_NAME}.pbs.err
+
+set -uo pipefail
+RUN_DIR="$RUN_DIR"
+SOURCE_DIR="$SOURCE_DIR"
+NOTEBOOK_PATH="$NOTEBOOK_PATH"
+SAFE_NAME="$SAFE_NAME"
+RESULT_JSON="$RESULT_JSON"
+CONDA_MODULE="$CONDA_MODULE"
+MODULE_BASE_PATH="$MODULE_BASE_PATH"
+COMMIT="$COMMIT"
+START_EPOCH=\$(date +%s)
+STATUS=failed
+EXIT_CODE=0
+
+mkdir -p "\$RUN_DIR/logs" "\$RUN_DIR/results" "\$RUN_DIR/outputs"
+cd "\$SOURCE_DIR" || exit 20
+
+{
+  echo "COSIMA smoke test started at \$(date -Is)"
+  echo "PBS job id: \${PBS_JOBID:-unknown}"
+  echo "Notebook: \$NOTEBOOK_PATH"
+  echo "Commit: \$COMMIT"
+  if ! command -v module >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    source /etc/profile >/dev/null 2>&1 || true
+  fi
+  module use "\$MODULE_BASE_PATH"
+  module load "\$CONDA_MODULE"
+  module list
+  python --version
+  python -m jupyter nbconvert --to notebook --execute "\$NOTEBOOK_PATH" \
+    --ExecutePreprocessor.timeout=1800 \
+    --output "\${SAFE_NAME}.executed.ipynb" \
+    --output-dir "\$RUN_DIR/outputs"
+  EXIT_CODE=\$?
+} > "\$RUN_DIR/logs/\${SAFE_NAME}.notebook.log" 2>&1 || EXIT_CODE=\$?
+
+END_EPOCH=\$(date +%s)
+if [[ "\$EXIT_CODE" -eq 0 ]]; then
+  STATUS=passed
+else
+  STATUS=failed
+fi
+
+STATUS="\$STATUS" EXIT_CODE="\$EXIT_CODE" START_EPOCH="\$START_EPOCH" END_EPOCH="\$END_EPOCH" \
+  RUN_DIR="\$RUN_DIR" NOTEBOOK_PATH="\$NOTEBOOK_PATH" SAFE_NAME="\$SAFE_NAME" COMMIT="\$COMMIT" \
+  JOB_ID="\${PBS_JOBID:-unknown}" CONDA_MODULE="\$CONDA_MODULE" MODULE_BASE_PATH="\$MODULE_BASE_PATH" \
+  python3 - <<'PY'
+import json, os
+start = int(os.environ["START_EPOCH"])
+end = int(os.environ["END_EPOCH"])
+result = {
+    "status": os.environ["STATUS"],
+    "exit_code": int(os.environ["EXIT_CODE"]),
+    "notebook_path": os.environ["NOTEBOOK_PATH"],
+    "safe_name": os.environ["SAFE_NAME"],
+    "recipes_commit": os.environ["COMMIT"],
+    "pbs_job_id": os.environ["JOB_ID"],
+    "conda_module": os.environ["CONDA_MODULE"],
+    "module_base_path": os.environ["MODULE_BASE_PATH"],
+    "run_dir": os.environ["RUN_DIR"],
+    "log_path": f'{os.environ["RUN_DIR"]}/logs/{os.environ["SAFE_NAME"]}.notebook.log',
+    "executed_notebook": f'{os.environ["RUN_DIR"]}/outputs/{os.environ["SAFE_NAME"]}.executed.ipynb',
+    "started_epoch": start,
+    "finished_epoch": end,
+    "duration_seconds": end - start,
+}
+with open(os.path.join(os.environ["RUN_DIR"], "results", f'{os.environ["SAFE_NAME"]}.result.json'), "w", encoding="utf-8") as handle:
+    json.dump(result, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+
+exit "\$EXIT_CODE"
+EOF
+
+JOB_ID=$(qsub "$PBS_SCRIPT")
+JOB_ID=${JOB_ID%%[[:space:]]*}
+
+JOB_ID="$JOB_ID" RUN_DIR="$RUN_DIR" NOTEBOOK_PATH="$NOTEBOOK_PATH" SAFE_NAME="$SAFE_NAME" COMMIT="$COMMIT" \
+  CONDA_MODULE="$CONDA_MODULE" MODULE_BASE_PATH="$MODULE_BASE_PATH" RESULT_JSON="$RESULT_JSON" PBS_SCRIPT="$PBS_SCRIPT" \
+  python3 - <<'PY'
+import json, os
+submitted = {
+    "status": "submitted",
+    "pbs_job_id": os.environ["JOB_ID"],
+    "notebook_path": os.environ["NOTEBOOK_PATH"],
+    "safe_name": os.environ["SAFE_NAME"],
+    "recipes_commit": os.environ["COMMIT"],
+    "conda_module": os.environ["CONDA_MODULE"],
+    "module_base_path": os.environ["MODULE_BASE_PATH"],
+    "run_dir": os.environ["RUN_DIR"],
+    "result_json": os.environ["RESULT_JSON"],
+    "pbs_script": os.environ["PBS_SCRIPT"],
+}
+with open(os.path.join(os.environ["RUN_DIR"], "results", f'{os.environ["SAFE_NAME"]}.submitted.json'), "w", encoding="utf-8") as handle:
+    json.dump(submitted, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+print(json.dumps(submitted, sort_keys=True))
+PY

--- a/scripts/plan_cosima_smoke.py
+++ b/scripts/plan_cosima_smoke.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Plan a single COSIMA Recipes smoke-test run from a small JSON manifest."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import PurePosixPath
+from typing import Any
+
+SAFE_VALUE = re.compile(r"^[A-Za-z0-9_./:+@=-]+$")
+SAFE_RESOURCE = re.compile(r"^[A-Za-z0-9_./:+-]+$")
+SAFE_WALLTIME = re.compile(r"^\d{2}:\d{2}:\d{2}$")
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    sys.exit(2)
+
+
+def require_safe_path(path: str) -> str:
+    if not path:
+        fail("notebook path must not be empty")
+    p = PurePosixPath(path)
+    if p.is_absolute() or ".." in p.parts:
+        fail(f"unsafe notebook path: {path!r}")
+    if p.suffix != ".ipynb":
+        fail(f"notebook path must end in .ipynb: {path!r}")
+    if not SAFE_VALUE.match(path):
+        fail(f"notebook path contains unsupported characters: {path!r}")
+    return p.as_posix()
+
+
+def require_safe_value(label: str, value: str, pattern: re.Pattern[str] = SAFE_VALUE) -> str:
+    if value is None or value == "":
+        fail(f"{label} must not be empty")
+    if not pattern.match(value):
+        fail(f"{label} contains unsupported characters: {value!r}")
+    return value
+
+
+def sanitize_name(path: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", path).strip("-._")
+    return safe or "notebook"
+
+
+def load_manifest(path: str) -> dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def merge(defaults: dict[str, Any], entry: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    planned = dict(defaults)
+    planned.update(entry)
+    for key, value in overrides.items():
+        if value not in (None, ""):
+            planned[key] = value
+    return planned
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--notebook-path", required=True)
+    parser.add_argument("--recipes-ref", default="")
+    parser.add_argument("--conda-module", default="")
+    parser.add_argument("--module-base-path", default="")
+    parser.add_argument("--poll-timeout-minutes", default="")
+    parser.add_argument("--out", default="planned-run.json")
+    args = parser.parse_args()
+
+    manifest = load_manifest(args.manifest)
+    defaults = manifest.get("defaults", {})
+    notebooks = manifest.get("notebooks", [])
+    requested_path = require_safe_path(args.notebook_path)
+
+    matches = [entry for entry in notebooks if entry.get("path") == requested_path]
+    if not matches:
+        known = ", ".join(entry.get("path", "<missing>") for entry in notebooks) or "<none>"
+        fail(f"notebook {requested_path!r} is not in the Stage 1 manifest. Known notebooks: {known}")
+
+    planned = merge(defaults, matches[0], {
+        "recipes_ref": args.recipes_ref,
+        "conda_module": args.conda_module,
+        "module_base_path": args.module_base_path,
+        "poll_timeout_minutes": args.poll_timeout_minutes,
+    })
+    planned["path"] = requested_path
+    planned["safe_name"] = sanitize_name(requested_path)
+
+    # Validate values passed to shell/PBS. This is intentionally conservative.
+    require_safe_value("repository_url", planned["repository_url"])
+    require_safe_value("recipes_ref", planned["recipes_ref"])
+    require_safe_value("project", planned["project"])
+    require_safe_value("queue", planned["queue"])
+    require_safe_value("walltime", planned["walltime"], SAFE_WALLTIME)
+    require_safe_value("memory", planned["memory"], SAFE_RESOURCE)
+    require_safe_value("storage", planned["storage"], SAFE_RESOURCE)
+    require_safe_value("conda_module", planned["conda_module"])
+    require_safe_value("module_base_path", planned["module_base_path"])
+    planned["ncpus"] = int(planned.get("ncpus", 1))
+    planned["poll_interval_seconds"] = int(planned.get("poll_interval_seconds", 60))
+    planned["poll_timeout_minutes"] = int(planned.get("poll_timeout_minutes", 45))
+
+    with open(args.out, "w", encoding="utf-8") as handle:
+        json.dump(planned, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as handle:
+            for key in [
+                "repository_url", "recipes_ref", "project", "queue", "walltime", "memory",
+                "storage", "conda_module", "module_base_path", "path", "safe_name",
+                "poll_interval_seconds", "poll_timeout_minutes", "ncpus",
+            ]:
+                handle.write(f"{key}={planned[key]}\n")
+    else:
+        print(json.dumps(planned, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a manually dispatched Stage 1 workflow for running one COSIMA Recipes notebook on Gadi via PBS.
- Add a JSON smoke-test manifest and planner validation for the default notebook path.
- Add Gadi submission and polling helper scripts that write actionable result metadata.
- Update the README with workflow behaviour and required repository secrets.

## Validation
- Ran the planner locally against `.github/configs/cosima-smoke.json` for `02-Appetisers/Barotropic_Streamfunction.ipynb`.
- Ran `bash -n` on the Gadi submit and poll scripts.
- Reviewed the staged diff before committing.

## Limitations
- Full GitHub Actions/Gadi validation still requires repository secrets and Gadi SSH/PBS access.
- Stage 1 intentionally runs only one notebook; expansion should follow after the first successful real Gadi run.