### PR TITLE
Fix COSIMA smoke workflow YAML

### DIFF
--- a/.github/workflows/cosima-recipe.yml
+++ b/.github/workflows/cosima-recipe.yml
@@ -114,12 +114,12 @@ jobs:
             '${{ steps.plan.outputs.storage }}' \
             < scripts/gadi_submit_cosima_smoke.sh | tee submit.json
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
-import json
-with open('submit.json', encoding='utf-8') as handle:
-    data = json.load(handle)
-for key in ('pbs_job_id', 'run_dir', 'result_json', 'pbs_script'):
-    print(f'{key}={data[key]}')
-PY
+          import json
+          with open('submit.json', encoding='utf-8') as handle:
+              data = json.load(handle)
+          for key in ('pbs_job_id', 'run_dir', 'result_json', 'pbs_script'):
+              print(f'{key}={data[key]}')
+          PY
 
       - name: Poll PBS result
         id: poll
@@ -136,16 +136,16 @@ PY
             < scripts/gadi_poll_cosima_smoke.sh | tee result.json
           poll_rc=${PIPESTATUS[0]}
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
-import json
-try:
-    with open('result.json', encoding='utf-8') as handle:
-        data = json.load(handle)
-except Exception as exc:
-    data = {'status': 'invalid-result-json', 'error': str(exc)}
-for key, value in data.items():
-    if isinstance(value, (str, int, float)):
-        print(f'{key}={value}')
-PY
+          import json
+          try:
+              with open('result.json', encoding='utf-8') as handle:
+                  data = json.load(handle)
+          except Exception as exc:
+              data = {'status': 'invalid-result-json', 'error': str(exc)}
+          for key, value in data.items():
+              if isinstance(value, (str, int, float)):
+                  print(f'{key}={value}')
+          PY
           echo "poll_exit_code=$poll_rc" >> "$GITHUB_OUTPUT"
 
       - name: Write job summary


### PR DESCRIPTION
## Summary
- Fix malformed YAML in `.github/workflows/cosima-recipe.yml` caused by unindented Python heredoc bodies inside `run: |` blocks.
- Keep the existing smoke-test workflow behaviour unchanged.

## Root cause
The failing run https://github.com/ACCESS-NRI/COSIMA-recipes-workflow/actions/runs/26441720907 failed before creating jobs because GitHub could not parse `.github/workflows/cosima-recipe.yml` at line 117. Two Python heredoc bodies were not indented as part of their YAML block scalar, so they were parsed as invalid top-level YAML.

## Fix
Indented both Python heredoc bodies and terminators inside the affected `run: |` blocks so GitHub Actions parses the workflow as valid YAML. The block scalar still renders the shell script with the heredoc delimiters at column 1, so shell behaviour is preserved.

## Validation
- Parsed all workflow YAML files with the `yaml` Node package.
- Extracted the affected `run:` scripts and validated them with `bash -n` after substituting GitHub expressions.
- Ran `python3 -m py_compile scripts/plan_cosima_smoke.py`.
- Ran `bash -n scripts/gadi_submit_cosima_smoke.sh scripts/gadi_poll_cosima_smoke.sh`.
- Ran `scripts/plan_cosima_smoke.py` with the default smoke-test inputs and verified it produced the expected planned run JSON.
