### PR TITLE
Force smoke test nbconvert kernel to python3

### DIFF
--- a/scripts/gadi_submit_cosima_smoke.sh
+++ b/scripts/gadi_submit_cosima_smoke.sh
@@ -89,6 +89,7 @@ cd "\$SOURCE_DIR" || exit 20
   module list
   python --version
   python -m jupyter nbconvert --to notebook --execute "\$NOTEBOOK_PATH" \
+    --ExecutePreprocessor.kernel_name=python3 \
     --ExecutePreprocessor.timeout=1800 \
     --output "\${SAFE_NAME}.executed.ipynb" \
     --output-dir "\$RUN_DIR/outputs"


### PR DESCRIPTION
## Summary
- Force the Gadi COSIMA smoke-test notebook execution to use the `python3` kernel via `--ExecutePreprocessor.kernel_name=python3`.

## Root cause
The smoke-test notebook was failing because `jupyter nbconvert --execute` was selecting an incorrect or unavailable kernel when run on Gadi. Explicitly specifying `python3` ensures the correct environment is used.