### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/cosima-recipe.yml
+++ b/.github/workflows/cosima-recipe.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Plan smoke test
         id: plan

--- a/.github/workflows/job-dashboard.yml
+++ b/.github/workflows/job-dashboard.yml
@@ -26,14 +26,14 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Use a personal access token or the default token with proper permissions
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0  # Fetch all history for all branches
           
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           


### PR DESCRIPTION
Automated update of GitHub Actions to versions that run on the Node.js 24 runtime, replacing deprecated Node.js 16/20 versions.

All workflow YAML changes are limited to official GitHub Actions major version bumps (e.g. `actions/checkout`, `actions/setup-python`, etc.).