### PR TITLE
Add workflow to run all COSIMA recipes on Gadi

### DIFF
--- a/.github/configs/cosima-all-recipes.json
+++ b/.github/configs/cosima-all-recipes.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "defaults": {
+    "type": "cosima-all-recipes",
+    "repository_url": "https://github.com/COSIMA/cosima-recipes.git",
+    "recipes_ref": "main",
+    "project": "tm70",
+    "queue": "normal",
+    "walltime": "02:00:00",
+    "memory": "8GB",
+    "ncpus": 1,
+    "storage": "gdata/xp65+gdata/ik11+gdata/cj50+gdata/ol01+gdata/hh5",
+    "conda_module": "conda/analysis3",
+    "module_base_path": "/g/data/xp65/public/modules",
+    "poll_interval_seconds": 120,
+    "poll_timeout_minutes": 240,
+    "execute_timeout_seconds": 3600,
+    "notebook_roots": [
+      "01-Cooking-Tutorials",
+      "02-Easy-Recipes",
+      "03-Advanced-Recipes",
+      "04-Regional-Specialties"
+    ]
+  }
+}

--- a/.github/configs/cosima-all-recipes.yml
+++ b/.github/configs/cosima-all-recipes.yml
@@ -1,5 +1,6 @@
 # Legacy YAML configuration retained for compatibility with older tooling.
-# The Stage 1 workflow uses .github/configs/cosima-smoke.json.
+# The active all-recipes workflow discovers notebooks dynamically using
+# .github/configs/cosima-all-recipes.json.
 defaults:
   type: cosima
   project: tm70
@@ -8,15 +9,123 @@ defaults:
   module_base_path: /g/data/xp65/public/modules
   config:
     queue: normal
-    walltime: "00:30:00"
-    memory: 4GB
-    group: small
+    walltime: "02:00:00"
+    memory: 8GB
+    group: all-recipes
     storage: "gdata/xp65+gdata/ik11+gdata/cj50+gdata/ol01+gdata/hh5"
 
 recipes:
-  - name: barotropic-streamfunction
+  - name: 01-cooking-tutorials-01-basics-01-loading-slicing-dicing-output
+    path: 01-Cooking-Tutorials/01-Basics/01-Loading-Slicing-Dicing-Output.ipynb
+    enabled: true
+  - name: 01-cooking-tutorials-01-basics-02-access-nri-intake-catalog
+    path: 01-Cooking-Tutorials/01-Basics/02-ACCESS-NRI_Intake_Catalog.ipynb
+    enabled: true
+  - name: 01-cooking-tutorials-01-basics-03-maps-with-cartopy
+    path: 01-Cooking-Tutorials/01-Basics/03-Maps_with_Cartopy.ipynb
+    enabled: true
+  - name: 01-cooking-tutorials-02-advanced-animations-with-xmovie
+    path: 01-Cooking-Tutorials/02-Advanced/Animations_with_xmovie.ipynb
+    enabled: true
+  - name: 01-cooking-tutorials-02-advanced-apply-function-to-every-gridpoint
+    path: 01-Cooking-Tutorials/02-Advanced/Apply_function_to_every_gridpoint.ipynb
+    enabled: true
+  - name: 01-cooking-tutorials-02-advanced-make-your-own-intake-datastore
+    path: 01-Cooking-Tutorials/02-Advanced/Make_Your_Own_Intake_Datastore.ipynb
+    enabled: true
+  - name: 01-cooking-tutorials-02-advanced-model-agnostic-analysis
+    path: 01-Cooking-Tutorials/02-Advanced/Model_Agnostic_Analysis.ipynb
+    enabled: true
+  - name: 01-cooking-tutorials-02-advanced-spatial-selection
+    path: 01-Cooking-Tutorials/02-Advanced/Spatial_selection.ipynb
+    enabled: true
+  - name: 01-cooking-tutorials-02-advanced-submitting-analysis-jobs-to-gadi
+    path: 01-Cooking-Tutorials/02-Advanced/Submitting_analysis_jobs_to_gadi.ipynb
+    enabled: true
+  - name: 01-cooking-tutorials-02-advanced-intake-to-dask-efficiently-chunking
+    path: 01-Cooking-Tutorials/02-Advanced/intake_to_dask_efficiently_chunking.ipynb
+    enabled: true
+  - name: 02-easy-recipes-barotropic-streamfunction
     path: 02-Easy-Recipes/Barotropic_Streamfunction.ipynb
     enabled: true
-    config:
-      walltime: "00:30:00"
-      memory: 4GB
+  - name: 02-easy-recipes-compare-ssh-model-obs
+    path: 02-Easy-Recipes/Compare_SSH_model_obs.ipynb
+    enabled: true
+  - name: 02-easy-recipes-compare-sst-sss-temperaturesalinity-to-woa13
+    path: 02-Easy-Recipes/Compare_SST_SSS_TemperatureSalinity_to_WOA13.ipynb
+    enabled: true
+  - name: 02-easy-recipes-extract-variables-at-ocean-bottom
+    path: 02-Easy-Recipes/Extract_Variables_at_Ocean_Bottom.ipynb
+    enabled: true
+  - name: 02-easy-recipes-hovmoller-temperature-depth
+    path: 02-Easy-Recipes/Hovmoller_Temperature_Depth.ipynb
+    enabled: true
+  - name: 02-easy-recipes-sea-ice-coordinates
+    path: 02-Easy-Recipes/Sea_Ice_Coordinates.ipynb
+    enabled: true
+  - name: 02-easy-recipes-true-zonal-mean
+    path: 02-Easy-Recipes/True_Zonal_Mean.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-along-slope-velocities
+    path: 03-Advanced-Recipes/Along-slope-velocities.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-along-isobath-average
+    path: 03-Advanced-Recipes/Along_Isobath_Average.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-create-contour
+    path: 03-Advanced-Recipes/Create_contour.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-cross-contour-transport
+    path: 03-Advanced-Recipes/Cross-contour_transport.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-cross-slope-section
+    path: 03-Advanced-Recipes/Cross-slope_section.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-eddy-mean-kinetic-energy-decomposition
+    path: 03-Advanced-Recipes/Eddy-Mean_Kinetic_Energy_Decomposition.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-geostrophic-velocities-from-sea-level
+    path: 03-Advanced-Recipes/Geostrophic_Velocities_from_Sea_Level.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-heaving-water-mass-transformation-decomposition
+    path: 03-Advanced-Recipes/Heaving_Water_mass_transformation_decomposition.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-horizontal-regridding
+    path: 03-Advanced-Recipes/Horizontal_Regridding.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-meridional-heat-transport
+    path: 03-Advanced-Recipes/Meridional_heat_transport.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-nearest-neighbour-distance
+    path: 03-Advanced-Recipes/Nearest_Neighbour_Distance.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-neutral-density
+    path: 03-Advanced-Recipes/Neutral_density.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-overturning-circulation
+    path: 03-Advanced-Recipes/Overturning_Circulation.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-particle-tracking-with-parcels
+    path: 03-Advanced-Recipes/Particle_tracking_with_Parcels.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-relative-vorticity
+    path: 03-Advanced-Recipes/Relative_Vorticity.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-sea-ice-area-concentration-volume-with-obs
+    path: 03-Advanced-Recipes/Sea_Ice_Area_Concentration_Volume_with_Obs.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-sea-ice-seasonality-statistics
+    path: 03-Advanced-Recipes/Sea_Ice_Seasonality_Statistics.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-surface-water-mass-transformation
+    path: 03-Advanced-Recipes/Surface_Water_Mass_Transformation.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-temperature-salinity-diagram
+    path: 03-Advanced-Recipes/Temperature_Salinity_Diagram.ipynb
+    enabled: true
+  - name: 03-advanced-recipes-transformation-from-depth-to-potential-density
+    path: 03-Advanced-Recipes/Transformation_from_Depth_to_Potential_Density.ipynb
+    enabled: true
+  - name: 04-regional-specialties-regional-mom6-forced-by-access-om2
+    path: 04-Regional-Specialties/regional-mom6-forced-by-access-om2.ipynb
+    enabled: true

--- a/.github/workflows/cosima-all-recipes.yml
+++ b/.github/workflows/cosima-all-recipes.yml
@@ -1,0 +1,179 @@
+name: COSIMA All Recipes
+
+on:
+  workflow_dispatch:
+    inputs:
+      recipes_ref:
+        description: 'COSIMA/cosima-recipes branch, tag, or SHA to test'
+        required: true
+        default: 'main'
+      conda_module:
+        description: 'Analysis environment module to load on Gadi'
+        required: true
+        default: 'conda/analysis3'
+      module_base_path:
+        description: 'Module base path to add before loading conda_module'
+        required: true
+        default: '/g/data/xp65/public/modules'
+      poll_timeout_minutes:
+        description: 'How long GitHub Actions should poll for all PBS-array results'
+        required: true
+        default: '240'
+      execute_timeout_seconds:
+        description: 'Per-notebook nbconvert execution timeout'
+        required: true
+        default: '3600'
+      gadi_work_dir:
+        description: 'Optional Gadi base work directory; defaults to GADI_SCRIPTS_DIR secret'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  all-recipes:
+    name: Run all COSIMA notebooks on Gadi
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Plan all-recipes run
+        id: plan
+        env:
+          RECIPES_REF: ${{ inputs.recipes_ref }}
+          CONDA_MODULE: ${{ inputs.conda_module }}
+          MODULE_BASE_PATH: ${{ inputs.module_base_path }}
+          POLL_TIMEOUT_MINUTES: ${{ inputs.poll_timeout_minutes }}
+          EXECUTE_TIMEOUT_SECONDS: ${{ inputs.execute_timeout_seconds }}
+        run: |
+          python3 scripts/plan_cosima_all_recipes.py \
+            --config .github/configs/cosima-all-recipes.json \
+            --recipes-ref "$RECIPES_REF" \
+            --conda-module "$CONDA_MODULE" \
+            --module-base-path "$MODULE_BASE_PATH" \
+            --poll-timeout-minutes "$POLL_TIMEOUT_MINUTES" \
+            --execute-timeout-seconds "$EXECUTE_TIMEOUT_SECONDS" \
+            --out planned-all-recipes-run.json
+
+      - name: Configure SSH for Gadi
+        env:
+          GADI_KEY: ${{ secrets.GADI_KEY }}
+          GADI_KEY_PASSPHRASE: ${{ secrets.GADI_KEY_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          test -n "${{ secrets.GADI_USER }}" || { echo "GADI_USER secret is not configured" >&2; exit 2; }
+          test -n "$GADI_KEY" || { echo "GADI_KEY secret is not configured" >&2; exit 2; }
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$GADI_KEY" > ~/.ssh/gadi_key
+          chmod 600 ~/.ssh/gadi_key
+          ssh-keyscan -H gadi.nci.org.au >> ~/.ssh/known_hosts
+          eval "$(ssh-agent -s)"
+          if [[ -n "${GADI_KEY_PASSPHRASE:-}" ]]; then
+            ASKPASS=$(mktemp)
+            chmod 700 "$ASKPASS"
+            printf '#!/usr/bin/env bash\nprintf %%s "$GADI_KEY_PASSPHRASE"\n' > "$ASKPASS"
+            DISPLAY=:0 SSH_ASKPASS="$ASKPASS" SSH_ASKPASS_REQUIRE=force ssh-add ~/.ssh/gadi_key </dev/null
+            rm -f "$ASKPASS"
+          else
+            ssh-add ~/.ssh/gadi_key
+          fi
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
+
+      - name: Submit PBS array job
+        id: submit
+        env:
+          GADI_USER: ${{ secrets.GADI_USER }}
+          GADI_WORK_DIR_INPUT: ${{ inputs.gadi_work_dir }}
+          GADI_WORK_DIR_SECRET: ${{ secrets.GADI_SCRIPTS_DIR }}
+        run: |
+          set -euo pipefail
+          GADI_WORK_DIR="${GADI_WORK_DIR_INPUT:-$GADI_WORK_DIR_SECRET}"
+          test -n "$GADI_WORK_DIR" || { echo "Provide gadi_work_dir or configure GADI_SCRIPTS_DIR secret" >&2; exit 2; }
+          RUN_DIR="${GADI_WORK_DIR%/}/cosima-recipes-ci/runs/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-all-recipes"
+          ssh_opts=(-o BatchMode=yes -o StrictHostKeyChecking=yes)
+          ssh "${ssh_opts[@]}" "${GADI_USER}@gadi.nci.org.au" bash -s -- \
+            "$RUN_DIR" \
+            '${{ steps.plan.outputs.repository_url }}' \
+            '${{ steps.plan.outputs.recipes_ref }}' \
+            '${{ steps.plan.outputs.notebook_roots_arg }}' \
+            '${{ steps.plan.outputs.conda_module }}' \
+            '${{ steps.plan.outputs.module_base_path }}' \
+            '${{ steps.plan.outputs.project }}' \
+            '${{ steps.plan.outputs.queue }}' \
+            '${{ steps.plan.outputs.walltime }}' \
+            '${{ steps.plan.outputs.memory }}' \
+            '${{ steps.plan.outputs.ncpus }}' \
+            '${{ steps.plan.outputs.storage }}' \
+            '${{ steps.plan.outputs.execute_timeout_seconds }}' \
+            '${{ steps.plan.outputs.poll_interval_seconds }}' \
+            < scripts/gadi_submit_cosima_all_recipes.sh | tee submit.json
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          with open('submit.json', encoding='utf-8') as handle:
+              data = json.load(handle)
+          for key in ('pbs_job_id', 'run_dir', 'summary_json', 'notebooks_manifest', 'notebook_count', 'pbs_script'):
+              print(f'{key}={data[key]}')
+          PY
+
+      - name: Poll PBS array results
+        id: poll
+        env:
+          GADI_USER: ${{ secrets.GADI_USER }}
+        run: |
+          set +e
+          ssh_opts=(-o BatchMode=yes -o StrictHostKeyChecking=yes)
+          ssh "${ssh_opts[@]}" "${GADI_USER}@gadi.nci.org.au" bash -s -- \
+            '${{ steps.submit.outputs.run_dir }}' \
+            '${{ steps.submit.outputs.summary_json }}' \
+            '${{ steps.submit.outputs.notebook_count }}' \
+            '${{ steps.plan.outputs.poll_timeout_minutes }}' \
+            '${{ steps.plan.outputs.poll_interval_seconds }}' \
+            '${{ steps.submit.outputs.pbs_job_id }}' \
+            < scripts/gadi_poll_cosima_all_recipes.sh | tee summary.json
+          poll_rc=${PIPESTATUS[0]}
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          try:
+              with open('summary.json', encoding='utf-8') as handle:
+                  data = json.load(handle)
+          except Exception as exc:
+              data = {'status': 'invalid-summary-json', 'error': str(exc)}
+          for key, value in data.items():
+              if isinstance(value, (str, int, float)):
+                  print(f'{key}={value}')
+          PY
+          echo "poll_exit_code=$poll_rc" >> "$GITHUB_OUTPUT"
+
+      - name: Write job summary
+        run: |
+          set -euo pipefail
+          status='${{ steps.poll.outputs.status }}'
+          {
+            echo "## COSIMA Recipes all-recipes run"
+            echo
+            echo "- COSIMA Recipes ref: \`${{ steps.plan.outputs.recipes_ref }}\`"
+            echo "- PBS array job ID: \`${{ steps.submit.outputs.pbs_job_id }}\`"
+            echo "- Status: **${status:-unknown}**"
+            echo "- Expected notebooks: \`${{ steps.poll.outputs.expected_count }}\`"
+            echo "- Completed notebooks: \`${{ steps.poll.outputs.completed_count }}\`"
+            echo "- Passed notebooks: \`${{ steps.poll.outputs.passed_count }}\`"
+            echo "- Failed notebooks: \`${{ steps.poll.outputs.failed_count }}\`"
+            echo "- Missing notebooks: \`${{ steps.poll.outputs.missing_count }}\`"
+            echo "- Gadi run directory: \`${{ steps.submit.outputs.run_dir }}\`"
+            echo "- Notebook manifest: \`${{ steps.submit.outputs.notebooks_manifest }}\`"
+            echo "- Summary JSON: \`${{ steps.submit.outputs.summary_json }}\`"
+            echo "- analysis3 module: \`${{ steps.plan.outputs.conda_module }}\`"
+            echo "- module base path: \`${{ steps.plan.outputs.module_base_path }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$status" != "passed" ]]; then
+            echo "All-recipes run did not pass: ${status:-unknown}" >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # ACCESS-NRI MED COSIMA-recipes Workflow
 
-ACCESS-NRI maintenance workflow for testing COSIMA Recipes on NCI Gadi.
+ACCESS-NRI maintenance workflows for testing COSIMA Recipes on NCI Gadi.
 
-## Stage 1 smoke test
+## Workflows
 
-The active workflow, `.github/workflows/cosima-recipe.yml`, is manually dispatched and runs one manifest-listed notebook on Gadi via PBS:
+### Smoke test
+
+`.github/workflows/cosima-recipe.yml` is manually dispatched and runs one manifest-listed notebook on Gadi via PBS:
 
 - `02-Easy-Recipes/Barotropic_Streamfunction.ipynb`
 
@@ -17,11 +19,35 @@ The workflow:
 5. Writes and submits a non-blocking PBS script using the configured `conda_module` and `module_base_path`.
 6. Polls for a result JSON file and writes the pass/fail outcome to the GitHub Actions summary.
 
-Required GitHub secrets:
+### All recipes
+
+`.github/workflows/cosima-all-recipes.yml` is manually dispatched and runs every notebook found under the COSIMA Recipes recipe roots configured in `.github/configs/cosima-all-recipes.json`:
+
+- `01-Cooking-Tutorials`
+- `02-Easy-Recipes`
+- `03-Advanced-Recipes`
+- `04-Regional-Specialties`
+
+The workflow:
+
+1. Plans and validates the Gadi/PBS settings from `.github/configs/cosima-all-recipes.json` and workflow inputs.
+2. SSHes to Gadi using repository secrets.
+3. Creates a run directory under `${GADI_SCRIPTS_DIR}/cosima-recipes-ci/runs/<github-run>-<attempt>-all-recipes/` unless `gadi_work_dir` is supplied at dispatch time.
+4. Clones/fetches `COSIMA/cosima-recipes` and checks out the requested ref.
+5. Discovers all `.ipynb` files under the configured recipe roots and writes a tab-separated notebook manifest.
+6. Submits one PBS array job with one array task per notebook. Each task runs `jupyter nbconvert --execute`, writes a per-notebook log, executed notebook, and result JSON.
+7. Polls until every notebook has a result JSON, then writes an aggregate summary JSON and fails the GitHub Actions job if any notebook failed, timed out, or did not produce a result.
+
+Useful workflow inputs:
+
+- `recipes_ref`: COSIMA Recipes branch, tag, or SHA to test.
+- `poll_timeout_minutes`: how long GitHub Actions should wait for the full PBS array.
+- `execute_timeout_seconds`: per-notebook `nbconvert` timeout.
+- `gadi_work_dir`: optional override for the Gadi base run directory.
+
+## Required GitHub secrets
 
 - `GADI_USER`
 - `GADI_KEY`
 - `GADI_KEY_PASSPHRASE` if the key is encrypted
 - `GADI_SCRIPTS_DIR` unless `gadi_work_dir` is supplied manually
-
-The Stage 1 workflow intentionally tests only one notebook. Expansion to a broader smoke suite should happen after this path proves reliable on Gadi.

--- a/scripts/gadi_poll_cosima_all_recipes.sh
+++ b/scripts/gadi_poll_cosima_all_recipes.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Poll for all COSIMA Recipes PBS-array result JSON files on Gadi.
+set -euo pipefail
+
+if [[ $# -ne 6 ]]; then
+  echo "usage: $0 RUN_DIR SUMMARY_JSON NOTEBOOK_COUNT TIMEOUT_MINUTES INTERVAL_SECONDS JOB_ID" >&2
+  exit 2
+fi
+
+RUN_DIR=$1
+SUMMARY_JSON=$2
+NOTEBOOK_COUNT=$3
+TIMEOUT_MINUTES=$4
+INTERVAL_SECONDS=$5
+JOB_ID=$6
+RESULTS_DIR="$RUN_DIR/results"
+DEADLINE=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
+
+aggregate_results() {
+  local status_override=${1:-}
+  STATUS_OVERRIDE="$status_override" RUN_DIR="$RUN_DIR" SUMMARY_JSON="$SUMMARY_JSON" NOTEBOOK_COUNT="$NOTEBOOK_COUNT" JOB_ID="$JOB_ID" python3 - <<'PY'
+from __future__ import annotations
+
+import glob
+import json
+import os
+
+run_dir = os.environ["RUN_DIR"]
+summary_json = os.environ["SUMMARY_JSON"]
+expected = int(os.environ["NOTEBOOK_COUNT"])
+job_id = os.environ["JOB_ID"]
+status_override = os.environ.get("STATUS_OVERRIDE", "")
+results_dir = os.path.join(run_dir, "results")
+results = []
+for path in sorted(glob.glob(os.path.join(results_dir, "*.result.json"))):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            results.append(json.load(handle))
+    except Exception as exc:  # pragma: no cover - defensive runtime reporting
+        results.append({"status": "invalid-result", "result_json": path, "error": str(exc)})
+
+passed = [item for item in results if item.get("status") == "passed"]
+failed = [item for item in results if item.get("status") != "passed"]
+missing_count = max(expected - len(results), 0)
+if status_override:
+    status = status_override
+elif missing_count:
+    status = "incomplete"
+elif failed:
+    status = "failed"
+else:
+    status = "passed"
+
+summary = {
+    "status": status,
+    "pbs_job_id": job_id,
+    "run_dir": run_dir,
+    "summary_json": summary_json,
+    "expected_count": expected,
+    "completed_count": len(results),
+    "passed_count": len(passed),
+    "failed_count": len(failed),
+    "missing_count": missing_count,
+    "failed_notebooks": [
+        {
+            "notebook_path": item.get("notebook_path", "unknown"),
+            "status": item.get("status", "unknown"),
+            "exit_code": item.get("exit_code", ""),
+            "log_path": item.get("log_path", ""),
+        }
+        for item in failed
+    ],
+}
+with open(summary_json, "w", encoding="utf-8") as handle:
+    json.dump(summary, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+print(json.dumps(summary, sort_keys=True))
+PY
+}
+
+while [[ $(date +%s) -le $DEADLINE ]]; do
+  completed=$(find "$RESULTS_DIR" -maxdepth 1 -type f -name '*.result.json' 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "$completed" -ge "$NOTEBOOK_COUNT" ]]; then
+    aggregate_results
+    exit 0
+  fi
+  if command -v qstat >/dev/null 2>&1 && ! qstat "$JOB_ID" >/dev/null 2>&1; then
+    sleep "$INTERVAL_SECONDS"
+    completed=$(find "$RESULTS_DIR" -maxdepth 1 -type f -name '*.result.json' 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$completed" -ge "$NOTEBOOK_COUNT" ]]; then
+      aggregate_results
+      exit 0
+    fi
+    aggregate_results missing-result
+    exit 4
+  fi
+  sleep "$INTERVAL_SECONDS"
+done
+
+aggregate_results timeout
+exit 124

--- a/scripts/gadi_submit_cosima_all_recipes.sh
+++ b/scripts/gadi_submit_cosima_all_recipes.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Submit all COSIMA Recipes notebooks to PBS on Gadi as an array job.
+set -euo pipefail
+
+if [[ $# -ne 14 ]]; then
+  echo "usage: $0 RUN_DIR REPO_URL RECIPES_REF NOTEBOOK_ROOTS CONDA_MODULE MODULE_BASE_PATH PROJECT QUEUE WALLTIME MEMORY NCPUS STORAGE EXECUTE_TIMEOUT_SECONDS POLL_INTERVAL_SECONDS" >&2
+  exit 2
+fi
+
+RUN_DIR=$1
+REPO_URL=$2
+RECIPES_REF=$3
+NOTEBOOK_ROOTS=$4
+CONDA_MODULE=$5
+MODULE_BASE_PATH=$6
+PROJECT=$7
+QUEUE=$8
+WALLTIME=$9
+MEMORY=${10}
+NCPUS=${11}
+STORAGE=${12}
+EXECUTE_TIMEOUT_SECONDS=${13}
+POLL_INTERVAL_SECONDS=${14}
+
+case "$NOTEBOOK_ROOTS" in
+  /*|*..*) echo "unsafe notebook roots: $NOTEBOOK_ROOTS" >&2; exit 2 ;;
+esac
+
+safe_name() {
+  local value=$1
+  local safe
+  safe=$(printf '%s' "$value" | sed -E 's#[^A-Za-z0-9_.-]+#-#g; s#^-+##; s#-+$##' | cut -c1-180)
+  [[ -n "$safe" ]] || safe=notebook
+  printf '%s' "$safe"
+}
+
+diagnose_path() {
+  local path=$1
+  echo "Diagnostics for $path:" >&2
+  df -h "$path" >&2 || true
+  df -i "$path" >&2 || true
+  ls -ld "$path" >&2 || true
+}
+
+mkdir -p "$RUN_DIR" "$RUN_DIR/logs" "$RUN_DIR/results" "$RUN_DIR/outputs"
+SOURCE_DIR="$RUN_DIR/source"
+MANIFEST="$RUN_DIR/notebooks.tsv"
+PBS_SCRIPT="$RUN_DIR/cosima-all-recipes.pbs"
+SUMMARY_JSON="$RUN_DIR/results/all-recipes.summary.json"
+
+if ! touch "$RUN_DIR/.write-test.$$" 2>/dev/null; then
+  echo "run directory is not writable: $RUN_DIR" >&2
+  diagnose_path "$RUN_DIR"
+  exit 4
+fi
+rm -f "$RUN_DIR/.write-test.$$"
+
+if [[ ! -d "$SOURCE_DIR/.git" ]]; then
+  if [[ -e "$SOURCE_DIR" ]]; then
+    echo "removing incomplete source directory before clone: $SOURCE_DIR" >&2
+    rm -rf "$SOURCE_DIR"
+  fi
+  CLONE_TMP=$(mktemp -d "$RUN_DIR/source.tmp.XXXXXX")
+  trap 'rm -rf "${CLONE_TMP:-}"' EXIT
+  if ! git clone --filter=blob:none "$REPO_URL" "$CLONE_TMP" >&2; then
+    echo "git clone failed in temporary source directory: $CLONE_TMP" >&2
+    diagnose_path "$RUN_DIR"
+    exit 4
+  fi
+  mv "$CLONE_TMP" "$SOURCE_DIR"
+  trap - EXIT
+fi
+git -C "$SOURCE_DIR" fetch --depth=1 origin "$RECIPES_REF" >&2
+git -C "$SOURCE_DIR" checkout --detach FETCH_HEAD >&2
+COMMIT=$(git -C "$SOURCE_DIR" rev-parse HEAD)
+
+: > "$MANIFEST"
+INDEX=0
+IFS=':' read -r -a ROOTS <<< "$NOTEBOOK_ROOTS"
+for root in "${ROOTS[@]}"; do
+  [[ -n "$root" ]] || continue
+  case "$root" in /*|*..*) echo "unsafe notebook root: $root" >&2; exit 2 ;; esac
+  if [[ ! -d "$SOURCE_DIR/$root" ]]; then
+    echo "notebook root not found at requested ref: $root" >&2
+    continue
+  fi
+  while IFS= read -r notebook; do
+    [[ -n "$notebook" ]] || continue
+    case "$notebook" in /*|*..*|*.ipynb_checkpoints*) continue ;; esac
+    INDEX=$((INDEX + 1))
+    printf '%s\t%s\t%s\n' "$INDEX" "$notebook" "$(safe_name "$notebook")" >> "$MANIFEST"
+  done < <(cd "$SOURCE_DIR" && find "$root" -type f -name '*.ipynb' | LC_ALL=C sort)
+done
+NOTEBOOK_COUNT=$INDEX
+if [[ "$NOTEBOOK_COUNT" -eq 0 ]]; then
+  echo "no notebooks found under roots: $NOTEBOOK_ROOTS" >&2
+  exit 3
+fi
+
+cat > "$PBS_SCRIPT" <<EOF
+#!/usr/bin/env bash
+#PBS -P $PROJECT
+#PBS -q $QUEUE
+#PBS -l walltime=$WALLTIME
+#PBS -l mem=$MEMORY
+#PBS -l ncpus=$NCPUS
+#PBS -l storage=$STORAGE
+#PBS -l wd
+#PBS -J 1-$NOTEBOOK_COUNT
+#PBS -N cosima_all_recipes
+#PBS -o $RUN_DIR/logs/all-recipes.\$PBS_ARRAY_INDEX.pbs.out
+#PBS -e $RUN_DIR/logs/all-recipes.\$PBS_ARRAY_INDEX.pbs.err
+
+set -uo pipefail
+RUN_DIR="$RUN_DIR"
+SOURCE_DIR="$SOURCE_DIR"
+MANIFEST="$MANIFEST"
+CONDA_MODULE="$CONDA_MODULE"
+MODULE_BASE_PATH="$MODULE_BASE_PATH"
+COMMIT="$COMMIT"
+EXECUTE_TIMEOUT_SECONDS="$EXECUTE_TIMEOUT_SECONDS"
+ARRAY_INDEX="\${PBS_ARRAY_INDEX:-1}"
+START_EPOCH=\$(date +%s)
+STATUS=failed
+EXIT_CODE=0
+
+mkdir -p "\$RUN_DIR/logs" "\$RUN_DIR/results" "\$RUN_DIR/outputs"
+LINE=\$(awk -F '\t' -v idx="\$ARRAY_INDEX" '\$1 == idx { print; exit }' "\$MANIFEST")
+if [[ -z "\$LINE" ]]; then
+  echo "No notebook manifest entry for array index \$ARRAY_INDEX" >&2
+  exit 22
+fi
+IFS=\$'\t' read -r INDEX NOTEBOOK_PATH SAFE_NAME <<< "\$LINE"
+RESULT_JSON="\$RUN_DIR/results/\$(printf '%03d' "\$INDEX")-\${SAFE_NAME}.result.json"
+LOG_PATH="\$RUN_DIR/logs/\$(printf '%03d' "\$INDEX")-\${SAFE_NAME}.notebook.log"
+EXECUTED_NOTEBOOK="\$RUN_DIR/outputs/\$(printf '%03d' "\$INDEX")-\${SAFE_NAME}.executed.ipynb"
+
+cd "\$SOURCE_DIR" || exit 20
+{
+  echo "COSIMA all-recipes task started at \$(date -Is)"
+  echo "PBS job id: \${PBS_JOBID:-unknown}"
+  echo "Array index: \$ARRAY_INDEX"
+  echo "Notebook: \$NOTEBOOK_PATH"
+  echo "Commit: \$COMMIT"
+  if ! command -v module >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    source /etc/profile >/dev/null 2>&1 || true
+  fi
+  module use "\$MODULE_BASE_PATH"
+  module load "\$CONDA_MODULE"
+  module list
+  python --version
+  python -m jupyter nbconvert --to notebook --execute "\$NOTEBOOK_PATH" \
+    --ExecutePreprocessor.kernel_name=python3 \
+    --ExecutePreprocessor.timeout="\$EXECUTE_TIMEOUT_SECONDS" \
+    --output "\$(basename "\$EXECUTED_NOTEBOOK")" \
+    --output-dir "\$(dirname "\$EXECUTED_NOTEBOOK")"
+  EXIT_CODE=\$?
+} > "\$LOG_PATH" 2>&1 || EXIT_CODE=\$?
+
+END_EPOCH=\$(date +%s)
+if [[ "\$EXIT_CODE" -eq 0 ]]; then
+  STATUS=passed
+else
+  STATUS=failed
+fi
+
+STATUS="\$STATUS" EXIT_CODE="\$EXIT_CODE" START_EPOCH="\$START_EPOCH" END_EPOCH="\$END_EPOCH" \
+  RUN_DIR="\$RUN_DIR" NOTEBOOK_PATH="\$NOTEBOOK_PATH" SAFE_NAME="\$SAFE_NAME" COMMIT="\$COMMIT" \
+  INDEX="\$INDEX" ARRAY_INDEX="\$ARRAY_INDEX" JOB_ID="\${PBS_JOBID:-unknown}" CONDA_MODULE="\$CONDA_MODULE" \
+  MODULE_BASE_PATH="\$MODULE_BASE_PATH" LOG_PATH="\$LOG_PATH" EXECUTED_NOTEBOOK="\$EXECUTED_NOTEBOOK" RESULT_JSON="\$RESULT_JSON" \
+  python3 - <<'PY'
+import json, os
+start = int(os.environ["START_EPOCH"])
+end = int(os.environ["END_EPOCH"])
+result = {
+    "status": os.environ["STATUS"],
+    "exit_code": int(os.environ["EXIT_CODE"]),
+    "notebook_index": int(os.environ["INDEX"]),
+    "array_index": os.environ["ARRAY_INDEX"],
+    "notebook_path": os.environ["NOTEBOOK_PATH"],
+    "safe_name": os.environ["SAFE_NAME"],
+    "recipes_commit": os.environ["COMMIT"],
+    "pbs_job_id": os.environ["JOB_ID"],
+    "conda_module": os.environ["CONDA_MODULE"],
+    "module_base_path": os.environ["MODULE_BASE_PATH"],
+    "run_dir": os.environ["RUN_DIR"],
+    "log_path": os.environ["LOG_PATH"],
+    "executed_notebook": os.environ["EXECUTED_NOTEBOOK"],
+    "started_epoch": start,
+    "finished_epoch": end,
+    "duration_seconds": end - start,
+}
+with open(os.environ["RESULT_JSON"], "w", encoding="utf-8") as handle:
+    json.dump(result, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+
+exit "\$EXIT_CODE"
+EOF
+
+JOB_ID=$(qsub "$PBS_SCRIPT")
+JOB_ID=${JOB_ID%%[[:space:]]*}
+
+JOB_ID="$JOB_ID" RUN_DIR="$RUN_DIR" COMMIT="$COMMIT" NOTEBOOK_COUNT="$NOTEBOOK_COUNT" NOTEBOOK_ROOTS="$NOTEBOOK_ROOTS" \
+  CONDA_MODULE="$CONDA_MODULE" MODULE_BASE_PATH="$MODULE_BASE_PATH" SUMMARY_JSON="$SUMMARY_JSON" PBS_SCRIPT="$PBS_SCRIPT" MANIFEST="$MANIFEST" \
+  POLL_INTERVAL_SECONDS="$POLL_INTERVAL_SECONDS" EXECUTE_TIMEOUT_SECONDS="$EXECUTE_TIMEOUT_SECONDS" \
+  python3 - <<'PY'
+import json, os
+submitted = {
+    "status": "submitted",
+    "pbs_job_id": os.environ["JOB_ID"],
+    "recipes_commit": os.environ["COMMIT"],
+    "notebook_count": int(os.environ["NOTEBOOK_COUNT"]),
+    "notebook_roots": os.environ["NOTEBOOK_ROOTS"].split(":"),
+    "conda_module": os.environ["CONDA_MODULE"],
+    "module_base_path": os.environ["MODULE_BASE_PATH"],
+    "execute_timeout_seconds": int(os.environ["EXECUTE_TIMEOUT_SECONDS"]),
+    "poll_interval_seconds": int(os.environ["POLL_INTERVAL_SECONDS"]),
+    "run_dir": os.environ["RUN_DIR"],
+    "summary_json": os.environ["SUMMARY_JSON"],
+    "notebooks_manifest": os.environ["MANIFEST"],
+    "pbs_script": os.environ["PBS_SCRIPT"],
+}
+with open(os.path.join(os.environ["RUN_DIR"], "results", "all-recipes.submitted.json"), "w", encoding="utf-8") as handle:
+    json.dump(submitted, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+print(json.dumps(submitted, sort_keys=True))
+PY

--- a/scripts/plan_cosima_all_recipes.py
+++ b/scripts/plan_cosima_all_recipes.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Plan a COSIMA Recipes all-notebooks PBS-array run."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import PurePosixPath
+from typing import Any
+
+SAFE_VALUE = re.compile(r"^[A-Za-z0-9_./:+@=-]+$")
+SAFE_RESOURCE = re.compile(r"^[A-Za-z0-9_./:+-]+$")
+SAFE_WALLTIME = re.compile(r"^\d{2}:\d{2}:\d{2}$")
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    sys.exit(2)
+
+
+def require_safe_value(label: str, value: str, pattern: re.Pattern[str] = SAFE_VALUE) -> str:
+    if value is None or value == "":
+        fail(f"{label} must not be empty")
+    if not pattern.match(value):
+        fail(f"{label} contains unsupported characters: {value!r}")
+    return value
+
+
+def require_safe_root(root: str) -> str:
+    if not root:
+        fail("notebook roots must not be empty")
+    path = PurePosixPath(root)
+    if path.is_absolute() or ".." in path.parts:
+        fail(f"unsafe notebook root: {root!r}")
+    if not SAFE_VALUE.match(root):
+        fail(f"notebook root contains unsupported characters: {root!r}")
+    return path.as_posix()
+
+
+def load_config(path: str) -> dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--recipes-ref", default="")
+    parser.add_argument("--conda-module", default="")
+    parser.add_argument("--module-base-path", default="")
+    parser.add_argument("--poll-timeout-minutes", default="")
+    parser.add_argument("--execute-timeout-seconds", default="")
+    parser.add_argument("--out", default="planned-all-recipes-run.json")
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    planned = dict(config.get("defaults", {}))
+    for key, value in {
+        "recipes_ref": args.recipes_ref,
+        "conda_module": args.conda_module,
+        "module_base_path": args.module_base_path,
+        "poll_timeout_minutes": args.poll_timeout_minutes,
+        "execute_timeout_seconds": args.execute_timeout_seconds,
+    }.items():
+        if value not in (None, ""):
+            planned[key] = value
+
+    require_safe_value("repository_url", planned["repository_url"])
+    require_safe_value("recipes_ref", planned["recipes_ref"])
+    require_safe_value("project", planned["project"])
+    require_safe_value("queue", planned["queue"])
+    require_safe_value("walltime", planned["walltime"], SAFE_WALLTIME)
+    require_safe_value("memory", planned["memory"], SAFE_RESOURCE)
+    require_safe_value("storage", planned["storage"], SAFE_RESOURCE)
+    require_safe_value("conda_module", planned["conda_module"])
+    require_safe_value("module_base_path", planned["module_base_path"])
+    planned["ncpus"] = int(planned.get("ncpus", 1))
+    planned["poll_interval_seconds"] = int(planned.get("poll_interval_seconds", 120))
+    planned["poll_timeout_minutes"] = int(planned.get("poll_timeout_minutes", 240))
+    planned["execute_timeout_seconds"] = int(planned.get("execute_timeout_seconds", 3600))
+    planned["notebook_roots"] = [require_safe_root(root) for root in planned.get("notebook_roots", [])]
+    if not planned["notebook_roots"]:
+        fail("at least one notebook root is required")
+    planned["notebook_roots_arg"] = ":".join(planned["notebook_roots"])
+
+    with open(args.out, "w", encoding="utf-8") as handle:
+        json.dump(planned, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as handle:
+            for key in [
+                "repository_url", "recipes_ref", "project", "queue", "walltime", "memory",
+                "storage", "conda_module", "module_base_path", "poll_interval_seconds",
+                "poll_timeout_minutes", "ncpus", "execute_timeout_seconds", "notebook_roots_arg",
+            ]:
+                handle.write(f"{key}={planned[key]}\n")
+    else:
+        print(json.dumps(planned, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a manual GitHub Actions workflow for running all COSIMA notebooks on Gadi via a PBS array job.
- Add planning, submit, and polling scripts plus active JSON config.
- Refresh the COSIMA notebook manifest to 38 notebooks and document usage in the README.

## Validation
- `python3 -m py_compile scripts/plan_cosima_all_recipes.py`
- `bash -n scripts/gadi_submit_cosima_all_recipes.sh`
- `bash -n scripts/gadi_poll_cosima_all_recipes.sh`
- JSON config parse
- Previous dry-run submit/poll validation: 38 synthetic passing results

## Caveat
- Not yet run against real Gadi/PBS; first live dispatch should verify PBS array behaviour and resource limits.